### PR TITLE
Fixed typo

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => {
       <div className="buttons-wrapper text-sm flex items-center gap-6">
         <a href={"/login"}>Login</a>
         <a href={"/signup"}>
-          <Button className="p-2 px-6 text-sm rounded-full">Get Strated</Button>
+          <Button className="p-2 px-6 text-sm rounded-full">Get Started</Button>
         </a>
       </div>
     </header>


### PR DESCRIPTION
There was a typo in the header button "Get Strated"

<img width="278" alt="image" src="https://github.com/NiazMorshed2007/popwola/assets/1942953/8c575cd6-357e-4cce-967b-409fd5ac4348">

which is fixed with this PR to "Get Started"